### PR TITLE
Fixing RocksDB SE build error

### DIFF
--- a/storage/rocksdb/rdb_cf_options.cc
+++ b/storage/rocksdb/rdb_cf_options.cc
@@ -67,7 +67,7 @@ bool Cf_options::SetDefault(const std::string &default_config) {
   if (!default_config.empty() &&
       !rocksdb::GetColumnFamilyOptionsFromString(options,
                                                  default_config,
-                                                 &options)) {
+                                                 &options).ok()) {
     fprintf(stderr,
             "Invalid default column family config: %s\n",
             default_config.c_str());
@@ -131,7 +131,8 @@ bool Cf_options::ParseConfigFile(const std::string &path) {
       return false;
     }
 
-    if (!rocksdb::GetColumnFamilyOptionsFromString(options, config, &options)) {
+    if (!rocksdb::GetColumnFamilyOptionsFromString(
+        options, config, &options).ok()) {
       fprintf(stderr,
               "Invalid column family config for %s in file %s: %s\n",
               cf.c_str(),


### PR DESCRIPTION
RocksDB diff https://reviews.facebook.net/D29223 changed
return type of rocksdb::GetDBOptionsFromString from
bool to rocksdb::Status. This caused RocksDB SE build error.
This diff fixes the build error.
